### PR TITLE
Fix broken images in read me plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "history": "^5.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-markdown": "^5.0.0",
+    "react-router": "^6.0.0-beta.0",
     "react-use": "^15.3.3",
-    "react-markdown": "^4.3.1",
-    "react-router": "^6.0.0-beta.0"
+    "remark-gfm": "^1.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.24",

--- a/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -39,10 +39,18 @@ const useStyles = makeStyles(theme => ({
     paddingRight: theme.spacing(1),
     '& table': {
       borderCollapse: 'collapse',
-      border: '1px solid #000',
+      border: '1px solid #dfe2e5',
+      color: 'rgb(36, 41, 46)',
     },
     '& th, & td': {
-      border: '1px solid #000',
+      border: '1px solid #dfe2e5',
+      padding: theme.spacing(1),
+    },
+    '& tr': {
+      backgroundColor: '#fff',
+    },
+    '& tr:nth-child(2n)': {
+      backgroundColor: '#f6f8fa',
     },
     '& pre': {
       padding: '16px',
@@ -84,6 +92,7 @@ type ReadMeCardProps = {
   entity: Entity;
   maxHeight?: number;
 };
+
 const getRepositoryDefaultBranch = (url: string) => {
   const repositoryUrl = (new URL(url).searchParams).get('ref');
   return repositoryUrl;


### PR DESCRIPTION
Images with relative path hosted on GitHub was not rendered correctly in the plugin. This PR resolve this issue.  Few style fixes was made too. Now links are blue and tables has borders and background colors is changed  so they are similar to the one on GitHub page. 

Table view:
![ZX0UUS6](https://user-images.githubusercontent.com/36006588/97289547-9c5cbc80-1847-11eb-8c7b-3adbc78f8092.png)

Image + link preview:
![tT0OfOK](https://user-images.githubusercontent.com/36006588/97289604-b4344080-1847-11eb-8088-d844d8784ecd.png)
