### PR TITLE
feat(sub-readme): Add optional README.md path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ const OverviewContent = ({ entity }: { entity: Entity }) => (
 
 ```
 
+## Readme path
+
+By default the plugin will use the annotation `github.com/project-slug` and get the root `README.md` from the repository. You can use a specific path by using the annotation `'github.com/project-readme-path': 'packages/sub-module/README.md'`. It can be useful if you have a component inside a monorepos.
+
 ## Features
 
 - Add GitHub Insights plugin tab.

--- a/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -63,9 +63,12 @@ const getRepositoryDefaultBranch = (url: string) => {
 };
 
 const ReadMeCard = ({ entity, maxHeight }: Props) => {
-  const { owner, repo } = useProjectEntity(entity);
+  const { owner, repo, readmePath } = useProjectEntity(entity);
   const classes = useStyles();
-  const { value, loading, error } = useRequest(entity, 'readme');
+  const request = readmePath ? `contents/${readmePath}` : "readme";
+  const path = readmePath || "README.MD";
+
+  const { value, loading, error } = useRequest(entity, request);
   const { hostname } = useUrl();
 
   if (loading) {
@@ -85,14 +88,14 @@ const ReadMeCard = ({ entity, maxHeight }: Props) => {
       deepLink={{
         link: `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
           value.url,
-        )}/README.md`,
+        )}/${path}`,
         title: 'Read me',
         onClick: e => {
           e.preventDefault();
           window.open(
             `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
               value.url,
-            )}/README.md`,
+            )}/${path}`,
           );
         },
       }}

--- a/src/hooks/useProjectEntity.ts
+++ b/src/hooks/useProjectEntity.ts
@@ -19,8 +19,14 @@ export const useProjectEntity = (entity: Entity) => {
   const projectSlug = entity.metadata?.annotations?.[
     'github.com/project-slug'
   ] as string;
+
+  const readmePath = entity.metadata?.annotations?.[
+    "github.com/project-readme-path"
+  ] as string;
+
   return {
-    owner: projectSlug.split('/')[0],
-    repo: projectSlug.split('/')[1],
+    owner: projectSlug.split("/")[0],
+    repo: projectSlug.split("/")[1],
+    readmePath,
   };
 };


### PR DESCRIPTION
Add the ability to choose a specific path to get the `README.md`.

I decided to use a new annotation: `github.com/project-readme-path`. This annotation is optional and the feature won't add any breaking change 😄 

Use case:
- A monorepo with multiple packages
- We can get only the package's README