### PR TITLE
Support Backstage TechDocs links in ReadMeCard

### DIFF
--- a/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -112,6 +112,9 @@ const ReadMeCard = ({ entity, maxHeight }: Props) => {
             `(//${hostname}/${owner}/${repo}/raw/${getRepositoryDefaultBranch(
               value.url
             )}`
+          ).replace(
+            /\[([^\[\]]*)\]\((?!https?:\/\/)(.*?)(\.md)\)/gim,
+            '[$1]($2/)'
           )}
         />
       </div>


### PR DESCRIPTION
When there are relative links that point to md files in the readme then reformat them as working TechDocs links in the ReadMeCard.

To test this
* Identify a Backstage component that has a techdocs site
* Edit the main README to include a relative link to one of the docs pages, e.g.

```
## Architecture
See, [architecture docs](docs/architecture.md)
```
* Load the Code Insights tab for this component in Backstage and click on the link
* You should be taken to the docs page in Backstage, whereas before it would show a 404