### PR TITLE
Add Compliance widget to insights page + remove deprecated prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-insights",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/InsightsPage/InsightsPage.tsx
+++ b/src/components/InsightsPage/InsightsPage.tsx
@@ -18,6 +18,7 @@ import { Grid } from '@material-ui/core';
 import { Page, Content, ContentHeader, SupportButton } from '@backstage/core';
 import { Entity } from '@backstage/catalog-model';
 import {
+  ComplianceCard,
   ContributorsCard,
   ReadMeCard,
   LanguagesCard,
@@ -45,6 +46,7 @@ const InsightsPage = (_props: Props) => {
             <ContributorsCard entity={entity} />
             <LanguagesCard entity={entity} />
             <ReleasesCard entity={entity} />
+            <ComplianceCard />
           </Grid>
           <Grid item sm={12} md={6} lg={8}>
             <ReadMeCard entity={entity} maxHeight={450} />

--- a/src/components/InsightsPage/InsightsPage.tsx
+++ b/src/components/InsightsPage/InsightsPage.tsx
@@ -43,13 +43,13 @@ const InsightsPage = (_props: Props) => {
         </ContentHeader>
         <Grid container spacing={3} direction="row" alignItems="stretch">
           <Grid item sm={12} md={6} lg={4}>
-            <ContributorsCard entity={entity} />
-            <LanguagesCard entity={entity} />
-            <ReleasesCard entity={entity} />
+            <ContributorsCard />
+            <LanguagesCard />
+            <ReleasesCard />
             <ComplianceCard />
           </Grid>
           <Grid item sm={12} md={6} lg={8}>
-            <ReadMeCard entity={entity} maxHeight={450} />
+            <ReadMeCard maxHeight={450} />
           </Grid>
         </Grid>
       </Content>


### PR DESCRIPTION
This PR does two things:

* Adds the compliance widget introduced in https://github.com/RoadieHQ/backstage-plugin-github-insights/pull/34 to the insights page. (I actually didn't know it existed, until VS Code auto suggested me to add it as an import!)
* Removes the deprecated prop from the cards in the insights page, since it's now no longer needed there.

Thanks!