### PR TITLE
Support non-ASCII chars in Readme

### DIFF
--- a/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -65,7 +65,7 @@ const getRepositoryDefaultBranch = (url: string) => {
 
 // Decoding base64 ⇢ UTF8
 // Taken from https://stackoverflow.com/a/30106551/6950
-function b64DecodeUnicode(str) {
+function b64DecodeUnicode(str: string): string {
   return decodeURIComponent(
     Array.prototype.map
       // eslint-disable-next-line func-names

--- a/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -63,6 +63,20 @@ const getRepositoryDefaultBranch = (url: string) => {
   return repositoryUrl;
 };
 
+// Decoding base64 ⇢ UTF8
+// Taken from https://stackoverflow.com/a/30106551/6950
+function b64DecodeUnicode(str) {
+  return decodeURIComponent(
+    Array.prototype.map
+      // eslint-disable-next-line func-names
+      .call(atob(str), function (c) {
+        // eslint-disable-next-line prefer-template
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join("")
+  );
+}
+
 const ReadMeCard = (props: Props) => {
   const { entity } = useEntity();
   const { owner, repo, readmePath } = useProjectEntity(entity);
@@ -109,7 +123,7 @@ const ReadMeCard = (props: Props) => {
         }}
       >
         <MarkdownContent
-          content={atob(value.content).replace(
+          content={b64DecodeUnicode(value.content).replace(
             /\[([^\[\]]*)\]\((?!https?:\/\/)(.*?)(\.md)\)/gim,
             '[$1]' + `(//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
               value.url

--- a/src/components/Widgets/ReadMeCard/ReadmeCard.test.tsx
+++ b/src/components/Widgets/ReadMeCard/ReadmeCard.test.tsx
@@ -77,4 +77,20 @@ describe('ReadmeCard', () => {
       )
     ).toBeInTheDocument();
   });
+  it('should render unicode correctly', async () => {
+    const rendered = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <ThemeProvider theme={lightTheme}>
+            <EntityProvider entity={entityMock}>
+              <ReadMeCard />
+            </EntityProvider>
+          </ThemeProvider>
+        </ApiProvider>
+      )
+    );
+    expect(
+      await rendered.findByText('⭐', { exact: false })
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fix "The Unicode problem" with Readme rendering via atob - https://stackoverflow.com/a/30106551/6950

Note that atob is also used for the license but as that is less likely to contain non-ascii chars I haven't implemented there.